### PR TITLE
NOTICKET: logError instead of verbose when issues sessionExpired

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/InformSessionError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/InformSessionError.swift
@@ -18,7 +18,8 @@ struct InformSessionError: Action {
 
     func execute(withDispatcher dispatcher: EventDispatcher, environment: Environment) async {
 
-        logVerbose("\(#fileID) Starting execution", environment: environment)
+        logError("\(#fileID) Starting execution, error: \(error)", environment: environment)
+
         var event: AuthorizationEvent
         switch error {
         case .service(let serviceError):


### PR DESCRIPTION
lets log this an error (WTH you don't do by default amplify?)